### PR TITLE
A handful of typos found on a train

### DIFF
--- a/depc/x/archaic.xml
+++ b/depc/x/archaic.xml
@@ -197,7 +197,7 @@ from Uruk and Umma \cite{Englund2009}.</p>
 
 <p>The other important--but numerically far smaller--group of texts
 are the word lists that Assyriologists generally refer to as `Lexical
-Texts'.  These appear in the earlist phases of writing and are
+Texts'.  These appear in the earliest phases of writing and are
 especially well evidenced in Uruk III texts.</p>
 
 <p>The best attested of these is the list of professions and

--- a/depc/x/rationale.xml
+++ b/depc/x/rationale.xml
@@ -16,8 +16,8 @@
   earlier than the ED IIIa corpus from Fara (Šuruppak): these are
   conventionally assigned to the Early Dynastic I-II period.  There
   are also about two dozen tablets and fragments from Uruk that are
-  assigned to the same period \cite[18
-  w.n.79]{LecompteVerderame2013}.</p>
+  assigned to the same period \cite[\pno~18
+  w.n.~79]{LecompteVerderame2013}.</p>
 
   <p>Texts and signs from this period are excluded from the
   proto-cuneiform proposal.</p>

--- a/mepc/pages/x/lists.xml
+++ b/mepc/pages/x/lists.xml
@@ -24,7 +24,7 @@
       
       <esp:ssh>The Intended Standard List</esp:ssh>
 
-      <p>The Berlin Uruk projected intended ATU2 <eb:cite
+      <p>The Berlin Uruk project intended ATU2 <eb:cite
       key="ATU2"/>, more commonly known as <code>ZATU</code>, to be
       the new standard list.  Published in 1987, the work lists many
       different sign forms for most signs, dividing them into Uruk IV
@@ -159,7 +159,7 @@
 	    number and a commodity.  Thus, |1(N57).AB₂| may mean "a
 	    one-year-old cow" and could equally well be notated as
 	    1(N57) AB₂--in fact, the corpus instances of such
-	    sequences often occur in bothforms.</p>
+	    sequences often occur in both forms.</p>
 	  </li>
 	</ul>
         </li>

--- a/pepc/principles.xml
+++ b/pepc/principles.xml
@@ -174,7 +174,7 @@
 	<li>Do not generally encode opaque sequences. In standard
 	transliteration practice for Proto-Cuneiform some signs are given
 	simple names which do not reflect their status as a sequence, e.g.,
-	LUGAL is actually a sequence of GAL₂ and LU₂, or LU₂ and GAL. We call
+	LUGAL is actually a sequence of GAL and LU₂, or LU₂ and GAL. We call
 	these sequences ``opaque sequences'' and, like regular sequences, they
 	are not encoded.</li>
 


### PR DESCRIPTION
Featuring lugal(𒅅𒇽): an existentialist king.

I tried to change the source files rather than the generated files (in particular, the files in `*/x/*` rather than `*/w/*`), but I did not rerun make (I think that ends up depending on Oracc), so you will have to rebuild.